### PR TITLE
added support for emoji + markdown + date/time + high-res twitter pics :grinning:

### DIFF
--- a/_includes/firebase-comment-form-template.html
+++ b/_includes/firebase-comment-form-template.html
@@ -1,12 +1,12 @@
 <div id="fbc-comment-form" style="display: none;">
   <button id="fbc-logout">Logout</button>
   <h4><span id="fbc-comment-count"></span> Comments</h4>
-  <textarea id="fbc-comment-message" rows="8" placeholder="Comment"></textarea>
+  <textarea id="fbc-comment-message" rows="8" placeholder="Comments support `markdown` and emoji :grinning:"></textarea>
   <button id="fbc-comment-form-submit">Submit</button>
 </div>
 
 <div id="fbc-login-buttons" style="display: none;">
-  <h4>Login to comment</h4>
+  <h4><span class="fbc-comment-count"></span> Comments &middot; Login to comment</h4>
   <button data-auth-provider="google">Google</button>
   <button data-auth-provider="facebook">Facebook</button>
   <button data-auth-provider="twitter">Twitter</button>

--- a/_includes/firebase-comment-template.html
+++ b/_includes/firebase-comment-template.html
@@ -1,5 +1,5 @@
 <div>
-  <a href="<%=link %>"><img src="<%=picture %>" style="height: 64px; width: 64px;"></a>
-  <a href="<%=link %>"><%=displayName %></a>
+  <a href="<%=link %>"><img src="<%=picture %>" style="height: 64px; width: 64px;" alt="<%=displayName %>"></a>
+  <%=time %> &middot; <a href="<%=link %>"><%=displayName %></a>
   <p><%=comment %></p>
 </div>

--- a/_includes/firebase-comments.ext
+++ b/_includes/firebase-comments.ext
@@ -163,7 +163,8 @@
           comment: messageComment, // no need to scrub again, already done on post!
           displayName: scrubComment(user.displayName),
           picture: scrubComment(user.picture),
-          link: scrubComment(user.link)
+          link: scrubComment(user.link),
+          time: scrubComment(messageTime)
         });
 
         $("#fbc-comments-list").append(commentHtml);

--- a/_includes/firebase-comments.ext
+++ b/_includes/firebase-comments.ext
@@ -152,6 +152,8 @@
     fbPostComments.on('child_added', function (snapshot) {
       var message = snapshot.val();
       var messageComment = message.comment;
+      var messageTime = new Date(message.time).toLocaleDateString();
+      if (messageTime == "Invalid Date"){messageTime = "¯\\_(ツ)_/¯";} // legacy support
 
       fb.child("users/" + message.uid).once('value', function (userSnap) {
         var user = userSnap.val();

--- a/_includes/firebase-comments.ext
+++ b/_includes/firebase-comments.ext
@@ -1,6 +1,10 @@
 <script src='https://cdn.firebase.com/js/client/1.0.15/firebase.js'></script>
 <script src='https://ajax.googleapis.com/ajax/libs/jquery/1.9.0/jquery.min.js'></script>
 <script src="https://cdn.firebase.com/js/simple-login/1.6.2/firebase-simple-login.js"></script>
+<script src='//cdnjs.cloudflare.com/ajax/libs/marked/0.3.2/marked.min.js'></script>
+<script src="//cdn.jsdelivr.net/emojione/1.1.0/lib/js/emojione.min.js" type="text/javascript"></script>
+<link rel="stylesheet" href="//cdn.jsdelivr.net/emojione/1.1.0/assets/css/emojione.min.css" type="text/css" media="all" />
+
 <script>
   //TODO: consider upgrading to something real like handlebar.js, but not handlebar since it conflicts with Jekyll's liquid templates
   // Simple JavaScript Templating
@@ -79,7 +83,7 @@
             currentUser.link = user.thirdPartyUserData.link;
             break;
           case "twitter":
-            currentUser.picture = user.thirdPartyUserData.profile_image_url;
+            currentUser.picture = user.thirdPartyUserData.profile_image_url.replace(/_normal/gi, "");
             currentUser.link = "http://twitter.com/" + user.thirdPartyUserData.screen_name;
             break;
           case "github":
@@ -127,7 +131,12 @@
       // re-enable the submit button
       $('#fbc-comment-form-submit').prop('disabled', false);
 
-      fbPostComments.push({'uid': currentUser.uid, 'comment': comment}, function (error) {
+			// add emoji & markdown parsing before insertion. should also sanitize inputs & prevent xss
+			// want to handle emoji & markdown on insert, instead of rendering on client side. 
+      emojione.imageType = 'svg'; // set svg for scalability instead of png (default)
+      comment = emojione.toImage(marked(comment));
+
+      fbPostComments.push({'uid': currentUser.uid, 'comment': comment, 'time': Firebase.ServerValue.TIMESTAMP}, function (error) {
         if (error != null) {
           alert(error.message + " Stop screwing around!")
         } else {
@@ -149,7 +158,7 @@
 
         // this is not working with an id reference to a template (possibly because it's 6 year old code), so give it the html instead
         var commentHtml = tmpl($("#fbc-comment-template").html(), {
-          comment: scrubComment(messageComment),
+          comment: messageComment, // no need to scrub again, already done on post!
           displayName: scrubComment(user.displayName),
           picture: scrubComment(user.picture),
           link: scrubComment(user.link)
@@ -159,7 +168,12 @@
       })
     });
     fbPostCommentCount.on('value', function (snapshot) {
-      $("#fbc-comment-count").text(snapshot.val());
+      if (snapshot.val() == null){
+        $(".fbc-comment-count").text("0");
+      } else {
+        	$(".fbc-comment-count").text(snapshot.val());
+      	}
+      
     });
   });
 


### PR DESCRIPTION
:grinning: Emoji (_shortcodes_) support via [emojione](https://github.com/ranks/emojione)
:pencil2: Markdown support via [marked](https://github.com/chjj/marked)
:arrow_up: emoji & markdown encoded when data is pushed to fb & js/css assets loaded via CDN

:speech_balloon: Comments now include date/time created. legacy fallback to ¯\_(ツ)_/¯
for old comments
:symbols: Also added regex to grab a higher resolution version of twitter profile
pics (what are we, retina-less savages?)
Also, made null comment counts read as :zero:. 

Extracted from my mods on [gitat.me](http://gitat.me)
